### PR TITLE
Adding required field: role_arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,7 @@ resource "aws_appautoscaling_target" "read_target" {
   resource_id        = "table/${var.dynamodb_table_name}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
+  role_arn           = "${aws_iam_role.autoscaler.arn}"
 }
 
 resource "aws_appautoscaling_policy" "read_policy" {
@@ -110,6 +111,7 @@ resource "aws_appautoscaling_target" "write_target" {
   resource_id        = "table/${var.dynamodb_table_name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
+  role_arn           = "${aws_iam_role.autoscaler.arn}"
 }
 
 resource "aws_appautoscaling_policy" "write_policy" {


### PR DESCRIPTION
I'm getting the following error while running the previous version:
```
Error: module.dynamodb_autoscaler.aws_appautoscaling_target.read_target: "role_arn": required field is not set
Error: module.dynamodb_autoscaler.aws_appautoscaling_target.write_target: "role_arn": required field is not set
```