### PR TITLE
Fix appautoscaling policy for global secondary indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ module "dynamodb_autoscaler" {
   dynamodb_table_name          = "cp-dev-cluster-terraform-state-lock"
   dynamodb_indexes             = [ "first-index", "second-index" ]
   dynamodb_table_arn           = "arn:aws:dynamodb:us-east-1:123456789012:table/cp-dev-cluster-terraform-state-lock"
-  autoscale_write_target       = 10
-  autoscale_read_target        = 10
+  autoscale_write_target       = 50
+  autoscale_read_target        = 50
   autoscale_min_read_capacity  = 5
   autoscale_max_read_capacity  = 20
   autoscale_min_write_capacity = 5
@@ -36,11 +36,11 @@ module "dynamodb_autoscaler" {
 | `dynamodb_table_name`            | ``           | DynamoDB table name                                                             | Yes      |
 | `dynamodb_indexes`               | `[]`         | List of DynamoDB indexes                                                        | No       |
 | `dynamodb_table_arn`             | ``           | DynamoDB table ARN                                                              | Yes      |
-| `attributes`                     | `[]`         | Additional attributes (_e.g._ `policy` or `role`)                               | No       |
+| `attributes`                     | `[]`         | Additional attributes (_e.g._ `1`)                                              | No       |
 | `tags`                           | `{}`         | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                            | No       |
-| `delimiter`                      | `-`          | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`     | No       |
-| `autoscale_write_target`         | `10`         | The target value for DynamoDB write autoscaling                                 | No       |
-| `autoscale_read_target`          | `10`         | The target value for DynamoDB read autoscaling                                  | No       |
+| `delimiter`                      | `-`          | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`      | No       |
+| `autoscale_write_target`         | `50`         | The target value for DynamoDB write autoscaling                                 | No       |
+| `autoscale_read_target`          | `50`         | The target value for DynamoDB read autoscaling                                  | No       |
 | `autoscale_min_read_capacity`    | `5`          | DynamoDB autoscaling min read capacity                                          | No       |
 | `autoscale_max_read_capacity`    | `20`         | DynamoDB autoscaling max read capacity                                          | No       |
 | `autoscale_min_write_capacity`   | `5`          | DynamoDB autoscaling min write capacity                                         | No       |
@@ -119,8 +119,8 @@ or [hire us][hire] to help build your next cloud-platform.
   [community]: https://github.com/cloudposse/
   [hire]: http://cloudposse.com/contact/
 
-### Contributors
 
+## Contributors
 
 | [![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] | [![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web] |
 |-------------------------------------------------------|------------------------------------------------------------------|

--- a/main.tf
+++ b/main.tf
@@ -113,12 +113,12 @@ resource "aws_appautoscaling_policy" "read_policy" {
 }
 
 resource "aws_appautoscaling_policy" "read_policy_index" {
-  count              = "${var.enabled == "true" ? 1 : 0}"
-  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.read_target_index.resource_id}"
+  count              = "${var.enabled == "true" ? length(var.dynamodb_indexes) : 0}"
+  name               = "DynamoDBReadCapacityUtilization:${element(aws_appautoscaling_target.read_target_index.*.resource_id, count.index)}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = "${aws_appautoscaling_target.read_target_index.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.read_target_index.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.read_target_index.service_namespace}"
+  resource_id        = "${element(aws_appautoscaling_target.read_target_index.*.resource_id, count.index)}"
+  scalable_dimension = "${element(aws_appautoscaling_target.read_target_index.*.scalable_dimension, count.index)}"
+  service_namespace  = "${element(aws_appautoscaling_target.read_target_index.*.service_namespace, count.index)}"
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
@@ -165,12 +165,12 @@ resource "aws_appautoscaling_policy" "write_policy" {
 }
 
 resource "aws_appautoscaling_policy" "write_policy_index" {
-  count              = "${var.enabled == "true" ? 1 : 0}"
-  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.write_target_index.resource_id}"
+  count              = "${var.enabled == "true" ? length(var.dynamodb_indexes) : 0}"
+  name               = "DynamoDBWriteCapacityUtilization:${element(aws_appautoscaling_target.write_target_index.*.resource_id, count.index)}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = "${aws_appautoscaling_target.write_target_index.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.write_target_index.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.write_target_index.service_namespace}"
+  resource_id        = "${element(aws_appautoscaling_target.write_target_index.*.resource_id, count.index)}"
+  scalable_dimension = "${element(aws_appautoscaling_target.write_target_index.*.scalable_dimension, count.index)}"
+  service_namespace  = "${element(aws_appautoscaling_target.write_target_index.*.service_namespace, count.index)}"
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {

--- a/variables.tf
+++ b/variables.tf
@@ -16,19 +16,19 @@ variable "name" {
 variable "delimiter" {
   type        = "string"
   default     = "-"
-  description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
   type        = "list"
   default     = []
-  description = "Additional attributes (e.g. `policy` or `role`)"
+  description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
   type        = "map"
   default     = {}
-  description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "dynamodb_table_name" {
@@ -48,12 +48,12 @@ variable "dynamodb_indexes" {
 }
 
 variable "autoscale_write_target" {
-  default     = 10
+  default     = 50
   description = "The target value for DynamoDB write autoscaling"
 }
 
 variable "autoscale_read_target" {
-  default     = 10
+  default     = 50
   description = "The target value for DynamoDB read autoscaling"
 }
 


### PR DESCRIPTION
## what
* Add `aws_appautoscaling_policy.read_policy_index` for global secondary indexes
* Add `aws_appautoscaling_policy.write_policy_index` for global secondary indexes

## why
* Missing
* Required for global secondary indexes

