### PR TITLE
Use `splat+join` pattern for resources with counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 ```hcl
 module "dynamodb_autoscaler" {
   source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler.git?ref=master"
-  namespace                    = "cp"
+  namespace                    = "eg"
   stage                        = "dev"
   name                         = "cluster"
-  dynamodb_table_name          = "cp-dev-cluster-terraform-state-lock"
+  dynamodb_table_name          = "eg-dev-cluster-terraform-state-lock"
   dynamodb_indexes             = [ "first-index", "second-index" ]
-  dynamodb_table_arn           = "arn:aws:dynamodb:us-east-1:123456789012:table/cp-dev-cluster-terraform-state-lock"
+  dynamodb_table_arn           = "arn:aws:dynamodb:us-east-1:123456789012:table/eg-dev-cluster-terraform-state-lock"
   autoscale_write_target       = 50
   autoscale_read_target        = 50
   autoscale_min_read_capacity  = 5
@@ -55,8 +55,9 @@ module "dynamodb_autoscaler" {
 ```
 Available targets:
 
-  help                                This help screen
+  help                                Help screen
   help/all                            Display help for all targets
+  help/short                          This help short screen
   lint                                Lint terraform code
 
 ```
@@ -78,7 +79,7 @@ Available targets:
 | dynamodb_table_name | DynamoDB table name | string | - | yes |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
+| namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`, `infra`) | string | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 

--- a/README.yaml
+++ b/README.yaml
@@ -47,12 +47,12 @@ usage: |-
   ```hcl
   module "dynamodb_autoscaler" {
     source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler.git?ref=master"
-    namespace                    = "cp"
+    namespace                    = "eg"
     stage                        = "dev"
     name                         = "cluster"
-    dynamodb_table_name          = "cp-dev-cluster-terraform-state-lock"
+    dynamodb_table_name          = "eg-dev-cluster-terraform-state-lock"
     dynamodb_indexes             = [ "first-index", "second-index" ]
-    dynamodb_table_arn           = "arn:aws:dynamodb:us-east-1:123456789012:table/cp-dev-cluster-terraform-state-lock"
+    dynamodb_table_arn           = "arn:aws:dynamodb:us-east-1:123456789012:table/eg-dev-cluster-terraform-state-lock"
     autoscale_write_target       = 50
     autoscale_read_target        = 50
     autoscale_min_read_capacity  = 5

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -2,8 +2,9 @@
 ```
 Available targets:
 
-  help                                This help screen
+  help                                Help screen
   help/all                            Display help for all targets
+  help/short                          This help short screen
   lint                                Lint terraform code
 
 ```

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,7 +16,7 @@
 | dynamodb_table_name | DynamoDB table name | string | - | yes |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
+| namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`, `infra`) | string | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "autoscaler" {
 resource "aws_iam_role_policy" "autoscaler" {
   count  = "${var.enabled == "true" ? 1 : 0}"
   name   = "${module.default_label.id}${var.delimiter}autoscaler${var.delimiter}dynamodb"
-  role   = "${aws_iam_role.autoscaler.id}"
+  role   = "${join("", aws_iam_role.autoscaler.*.id)}"
   policy = "${data.aws_iam_policy_document.autoscaler.json}"
 }
 
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "autoscaler_cloudwatch" {
 resource "aws_iam_role_policy" "autoscaler_cloudwatch" {
   count  = "${var.enabled == "true" ? 1 : 0}"
   name   = "${module.default_label.id}${var.delimiter}autoscaler${var.delimiter}cloudwatch"
-  role   = "${aws_iam_role.autoscaler.id}"
+  role   = "${join("", aws_iam_role.autoscaler.*.id)}"
   policy = "${data.aws_iam_policy_document.autoscaler_cloudwatch.json}"
 }
 
@@ -97,11 +97,11 @@ resource "aws_appautoscaling_target" "read_target_index" {
 
 resource "aws_appautoscaling_policy" "read_policy" {
   count              = "${var.enabled == "true" ? 1 : 0}"
-  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.read_target.resource_id}"
+  name               = "DynamoDBReadCapacityUtilization:${join("", aws_appautoscaling_target.read_target.*.resource_id)}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = "${aws_appautoscaling_target.read_target.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.read_target.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.read_target.service_namespace}"
+  resource_id        = "${join("", aws_appautoscaling_target.read_target.*.resource_id)}"
+  scalable_dimension = "${join("", aws_appautoscaling_target.read_target.*.scalable_dimension)}"
+  service_namespace  = "${join("", aws_appautoscaling_target.read_target.*.service_namespace)}"
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
@@ -149,11 +149,11 @@ resource "aws_appautoscaling_target" "write_target_index" {
 
 resource "aws_appautoscaling_policy" "write_policy" {
   count              = "${var.enabled == "true" ? 1 : 0}"
-  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.write_target.resource_id}"
+  name               = "DynamoDBWriteCapacityUtilization:${join("", aws_appautoscaling_target.write_target.*.resource_id)}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = "${aws_appautoscaling_target.write_target.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.write_target.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.write_target.service_namespace}"
+  resource_id        = "${join("", aws_appautoscaling_target.write_target.*.resource_id)}"
+  scalable_dimension = "${join("", aws_appautoscaling_target.write_target.*.scalable_dimension)}"
+  service_namespace  = "${join("", aws_appautoscaling_target.write_target.*.service_namespace)}"
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "namespace" {
   type        = "string"
-  description = "Namespace (e.g. `cp` or `cloudposse`)"
+  description = "Namespace (e.g. `eg` or `cp`)"
 }
 
 variable "stage" {


### PR DESCRIPTION
## what
* Use `splat+join` pattern for resources with counts

## why
* To prevent errors when `var.enabled = false`
```
Resource 'aws_iam_role.autoscaler' not found for variable 'aws_iam_role.autoscaler.id'
```

* Address https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler/issues/6
