### PR TITLE
Add tags to autoscaler role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ resource "aws_iam_role" "autoscaler" {
   count              = "${var.enabled == "true" ? 1 : 0}"
   name               = "${module.default_label.id}${var.delimiter}autoscaler"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  tags               = "${var.tags}"
 }
 
 data "aws_iam_policy_document" "autoscaler" {

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_iam_role" "autoscaler" {
   count              = "${var.enabled == "true" ? 1 : 0}"
   name               = "${module.default_label.id}${var.delimiter}autoscaler"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-  tags               = "${var.tags}"
+  tags               = "${module.default_label.tags}"
 }
 
 data "aws_iam_policy_document" "autoscaler" {


### PR DESCRIPTION
IAM roles now support tagging.
With this change the role created for autoscaler will inherit the tags passed as a variable.

AWS docs: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html