### PR TITLE
Remove dynamodb_table_arn

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -69,7 +69,6 @@ usage: |-
     name                         = "cluster"
     dynamodb_table_name          = "eg-dev-cluster-terraform-state-lock"
     dynamodb_indexes             = ["first-index", "second-index"]
-    dynamodb_table_arn           = "arn:aws:dynamodb:us-east-1:123456789012:table/eg-dev-cluster-terraform-state-lock"
     autoscale_write_target       = 50
     autoscale_read_target        = 50
     autoscale_min_read_capacity  = 5

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -11,7 +11,6 @@
 | autoscale_write_target | The target value for DynamoDB write autoscaling | number | `50` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
 | dynamodb_indexes | List of DynamoDB indexes | list(string) | `<list>` | no |
-| dynamodb_table_arn | DynamoDB table ARN | string | - | yes |
 | dynamodb_table_name | DynamoDB table name | string | - | yes |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,7 +8,6 @@ module "dynamodb_autoscaler" {
   stage                        = var.stage
   name                         = var.name
   dynamodb_table_name          = ""
-  dynamodb_table_arn           = ""
   autoscale_read_target        = var.autoscale_read_target
   autoscale_min_read_capacity  = var.autoscale_min_read_capacity
   autoscale_max_read_capacity  = var.autoscale_max_read_capacity

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,10 @@ module "default_label" {
   enabled     = var.enabled
 }
 
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "assume_role" {
   statement {
     sid = ""
@@ -43,7 +47,9 @@ data "aws_iam_policy_document" "autoscaler" {
       "dynamodb:UpdateTable"
     ]
 
-    resources = [var.dynamodb_table_arn]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb_table_name}"
+    ]
 
     effect = "Allow"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -51,11 +51,6 @@ variable "dynamodb_table_name" {
   description = "DynamoDB table name"
 }
 
-variable "dynamodb_table_arn" {
-  type        = string
-  description = "DynamoDB table ARN"
-}
-
 variable "dynamodb_indexes" {
   type        = list(string)
   description = "List of DynamoDB indexes"


### PR DESCRIPTION
We can infer it from var.dynamodb_table_name and the currently running
AWS provider configuration.

I wasn't able to test this, make terraform/lint failed, it seems like it is configured to use Terraform 0.11 instead of 0.12? Please let me know how to use the current test harness if there is some other command to run 👍 .