### PR TITLE
use minimum versions for provider pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,20 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| null | ~> 2.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
+| null | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -150,6 +151,7 @@ Available targets:
 | autoscaler\_iam\_role\_arn | Autoscaler IAM Role ARN |
 | autoscaler\_iam\_role\_id | Autoscaler IAM Role ID |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,16 +1,17 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| null | ~> 2.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
+| null | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -45,3 +46,4 @@
 | autoscaler\_iam\_role\_arn | Autoscaler IAM Role ARN |
 | autoscaler\_iam\_role\_id | Autoscaler IAM Role ID |
 
+<!-- markdownlint-restore -->

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws  = "~> 2.0"
-    null = "~> 2.0"
+    aws  = ">= 2.0"
+    null = ">= 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws  = ">= 2.0"


### PR DESCRIPTION
## what
set minimum versions for providers without pinning to a specific major version



## why
the current method makes it very difficult to maintain or upgrade consistent provider versions within a project



## references
https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions



