### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 

--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,12 @@ resource "aws_appautoscaling_target" "read_target_index" {
 
 resource "aws_appautoscaling_policy" "read_policy" {
   count       = module.this.enabled ? 1 : 0
-  name        = "DynamoDBReadCapacityUtilization:${join("", aws_appautoscaling_target.read_target.*.id)}"
+  name        = "DynamoDBReadCapacityUtilization:${join("", aws_appautoscaling_target.read_target[*].id)}"
   policy_type = "TargetTrackingScaling"
-  resource_id = join("", aws_appautoscaling_target.read_target.*.resource_id)
+  resource_id = join("", aws_appautoscaling_target.read_target[*].resource_id)
 
-  scalable_dimension = join("", aws_appautoscaling_target.read_target.*.scalable_dimension)
-  service_namespace  = join("", aws_appautoscaling_target.read_target.*.service_namespace)
+  scalable_dimension = join("", aws_appautoscaling_target.read_target[*].scalable_dimension)
+  service_namespace  = join("", aws_appautoscaling_target.read_target[*].service_namespace)
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
@@ -73,12 +73,12 @@ resource "aws_appautoscaling_target" "write_target_index" {
 
 resource "aws_appautoscaling_policy" "write_policy" {
   count       = module.this.enabled ? 1 : 0
-  name        = "DynamoDBWriteCapacityUtilization:${join("", aws_appautoscaling_target.write_target.*.id)}"
+  name        = "DynamoDBWriteCapacityUtilization:${join("", aws_appautoscaling_target.write_target[*].id)}"
   policy_type = "TargetTrackingScaling"
-  resource_id = join("", aws_appautoscaling_target.write_target.*.resource_id)
+  resource_id = join("", aws_appautoscaling_target.write_target[*].resource_id)
 
-  scalable_dimension = join("", aws_appautoscaling_target.write_target.*.scalable_dimension)
-  service_namespace  = join("", aws_appautoscaling_target.write_target.*.service_namespace)
+  scalable_dimension = join("", aws_appautoscaling_target.write_target[*].scalable_dimension)
+  service_namespace  = join("", aws_appautoscaling_target.write_target[*].service_namespace)
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "appautoscaling_read_policy_arn" {
-  value       = join("", aws_appautoscaling_policy.read_policy.*.arn)
+  value       = join("", aws_appautoscaling_policy.read_policy[*].arn)
   description = "Appautoscaling read policy ARN"
 }
 
 output "appautoscaling_write_policy_arn" {
-  value       = join("", aws_appautoscaling_policy.write_policy.*.arn)
+  value       = join("", aws_appautoscaling_policy.write_policy[*].arn)
   description = "Appautoscaling write policy ARN"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

Support AWS Provider V5
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
