### PR TITLE
feat: Add tags to aws_appautoscaling_target

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,8 @@ resource "aws_appautoscaling_target" "read_target" {
   resource_id        = "table/${var.dynamodb_table_name}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
+
+  tags = module.this.tags
 }
 
 resource "aws_appautoscaling_target" "read_target_index" {
@@ -14,6 +16,8 @@ resource "aws_appautoscaling_target" "read_target_index" {
   resource_id        = "table/${var.dynamodb_table_name}/index/${each.key}"
   scalable_dimension = "dynamodb:index:ReadCapacityUnits"
   service_namespace  = "dynamodb"
+
+  tags = module.this.tags
 }
 
 resource "aws_appautoscaling_policy" "read_policy" {


### PR DESCRIPTION
## what
Add missed tags

## why
Tags were introduced for all `aws_appautoscaling_target` resources created after 2023-03-20.

That blocks us from enforcing policy checks for missing tags.

## references
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target

Also, after release a new version here, we need release in https://github.com/cloudposse/terraform-aws-dynamodb/blob/a0cfac2e8c2584125596089a3185fc4a057410e4/main.tf#L153-L155