### PR TITLE
fix: Add tags to `aws_appautoscaling_target` resourses missed in previous PR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,8 @@ resource "aws_appautoscaling_target" "write_target" {
   resource_id        = "table/${var.dynamodb_table_name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
+
+  tags = module.this.tags
 }
 
 resource "aws_appautoscaling_target" "write_target_index" {
@@ -77,6 +79,8 @@ resource "aws_appautoscaling_target" "write_target_index" {
   resource_id        = "table/${var.dynamodb_table_name}/index/${each.key}"
   scalable_dimension = "dynamodb:index:WriteCapacityUnits"
   service_namespace  = "dynamodb"
+
+  tags = module.this.tags
 }
 
 resource "aws_appautoscaling_policy" "write_policy" {


### PR DESCRIPTION
## what
Add missed tags

## why
Tags were introduced for all `aws_appautoscaling_target` resources created after 2023-03-20.

That blocks us from enforcing policy checks for missing tags.

## references
Follow-up to https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler/pull/65


https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target

Also, after release a new version here, we need release in https://github.com/cloudposse/terraform-aws-dynamodb/blob/a0cfac2e8c2584125596089a3185fc4a057410e4/main.tf#L153-L155